### PR TITLE
modified raisim to facilitate raisimpy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 2.8.9)
 project (raisim_wrapper)
 
 # find the various packages
-find_package(pybind11 REQUIRED)
+find_package(pybind11 CONFIG 2.3 REQUIRED)
 find_package(Eigen3 REQUIRED eigen3)
 # find_package(OpenMP REQUIRED)
 find_package(raisim CONFIG REQUIRED)
@@ -22,7 +22,7 @@ include_directories(include ${EIGEN3_INCLUDE_DIRS})
 file(GLOB SOURCES "src/*.cpp")
 
 pybind11_add_module(raisimpy ${SOURCES})
-target_link_libraries(raisimpy raisim::raisim raisim::raisimOgre)
+target_link_libraries(raisimpy PRIVATE raisim::raisim raisim::raisimOgre)
 
 install (TARGETS raisimpy DESTINATION lib)
 # Don't forget to export PYTHONPATH=$PYTHONPATH:$LOCAL_BUILD/lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ project (raisim_wrapper)
 find_package(pybind11 CONFIG 2.3 REQUIRED)
 find_package(Eigen3 REQUIRED eigen3)
 # find_package(OpenMP REQUIRED)
-find_package(raisim CONFIG REQUIRED)
-find_package(raisimOgre CONFIG REQUIRED)
+find_package(raisim CONFIG 0.2.1 REQUIRED)
+find_package(raisimOgre CONFIG 0.2.1 REQUIRED)
 
 # header files
 include_directories(include ${EIGEN3_INCLUDE_DIRS})

--- a/README.rst
+++ b/README.rst
@@ -32,17 +32,7 @@ First, clone this repository:
     git clone https://github.com/robotlearn/raisimpy
     cd raisimpy
 
-
-Before compiling the code in this repo, you will have to move or copy the ``extras`` folder (that you can find in this
-repo) in the ``$LOCAL_BUILD/include/ode/`` folder. This ``extras`` folder contains some missing header files for ODE 
-which are necessary in order, for instance, to load meshes with Raisim. This can be done by:
-
-.. code-block:: bash
-
-    cp -r extras $LOCAL_BUILD/include/ode/
-
-
-Now, you can finally compile the python wrappers from the ``raisimpy`` folder by typing:
+Then, compile the python wrappers from the ``raisimpy`` folder by typing:
 
 .. code-block:: bash
 
@@ -175,29 +165,6 @@ Troubleshooting
         sudo ln -sf eigen3/unsupported unsupported
 
     or you can replace the ``#include <Eigen/*>`` by ``#include <eigen3/Eigen/*>``.
-
-- I can't close the GUI with ``Esc`` key nor by clicking the close button; I have to kill the process manually.
-    - In OgreVis.hpp, add the following line among the public methods:
-
-    .. code-block:: cpp
-
-        void closeApp();
-
-    - In OgreVis.cpp, add the following lines, and recompile:
-
-    .. code-block:: cpp
-
-        void OgreVis::closeApp() {
-            ApplicationContext::closeApp();
-            imGuiRenderCallback_ = nullptr;
-            imGuiSetupCallback_ = nullptr;
-            keyboardCallback_ = nullptr;
-            setUpCallback_ = nullptr;
-            controlCallback_ = nullptr;
-        }
-
-    You couldn't close the window because ``OgreVis`` would keep a reference to the Python callback functions, 
-    preventing Python to close properly (with ``pybind11``).
 
 - Segmentation fault. This is probably an oversight on my part, the error is probably due to some poor management 
   of pointers and memory allocation. E.g. an object has been deleted from the Python side but the C++ side is also 


### PR DESCRIPTION
I pushed raisim v0.2.1 today to make it work better with raisimpy. A few issues I addressed include

1. now extras folder are in raisimLib. These are private includes of ODE. Not exactly sure why you need them but I included them for now.
2. closeApp() method is added. readme of raisimpy is reflecting that change
3. The cmake of raisimpy now specifies which versions to use. I had an issue compiling raisimpy because it was dependent on v2.3 and I was using v2.2.3. It took some time to figure it out
4. raisimLib/Ogre readme now includes a link to raisimpy

If you want to change something on raisim or raisimOgre for your development, please submit a pull request or raise a github issue.

cheers,
Jemin

