### PR TITLE
make it compatible with raisim v0.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ project (raisim_wrapper)
 find_package(pybind11 CONFIG 2.3 REQUIRED)
 find_package(Eigen3 REQUIRED eigen3)
 # find_package(OpenMP REQUIRED)
-find_package(raisim CONFIG REQUIRED)
-find_package(raisimOgre CONFIG REQUIRED)
+find_package(raisim CONFIG 0.3.0 REQUIRED)
+find_package(raisimOgre CONFIG 0.3.0 REQUIRED)
 
 # header files
 include_directories(include ${EIGEN3_INCLUDE_DIRS})

--- a/README.rst
+++ b/README.rst
@@ -32,17 +32,7 @@ First, clone this repository:
     git clone https://github.com/robotlearn/raisimpy
     cd raisimpy
 
-
-Before compiling the code in this repo, you will have to move or copy the ``extras`` folder (that you can find in this
-repo) in the ``$LOCAL_BUILD/include/ode/`` folder. This ``extras`` folder contains some missing header files for ODE 
-which are necessary in order, for instance, to load meshes with Raisim. This can be done by:
-
-.. code-block:: bash
-
-    cp -r extras $LOCAL_BUILD/include/ode/
-
-
-Now, you can finally compile the python wrappers from the ``raisimpy`` folder by typing:
+Then, compile the python wrappers from the ``raisimpy`` folder by typing:
 
 .. code-block:: bash
 
@@ -175,29 +165,6 @@ Troubleshooting
         sudo ln -sf eigen3/unsupported unsupported
 
     or you can replace the ``#include <Eigen/*>`` by ``#include <eigen3/Eigen/*>``.
-
-- I can't close the GUI with ``Esc`` key nor by clicking the close button; I have to kill the process manually.
-    - In OgreVis.hpp, add the following line among the public methods:
-
-    .. code-block:: cpp
-
-        void closeApp();
-
-    - In OgreVis.cpp, add the following lines, and recompile:
-
-    .. code-block:: cpp
-
-        void OgreVis::closeApp() {
-            ApplicationContext::closeApp();
-            imGuiRenderCallback_ = nullptr;
-            imGuiSetupCallback_ = nullptr;
-            keyboardCallback_ = nullptr;
-            setUpCallback_ = nullptr;
-            controlCallback_ = nullptr;
-        }
-
-    You couldn't close the window because ``OgreVis`` would keep a reference to the Python callback functions, 
-    preventing Python to close properly (with ``pybind11``).
 
 - Segmentation fault. This is probably an oversight on my part, the error is probably due to some poor management 
   of pointers and memory allocation. E.g. an object has been deleted from the Python side but the C++ side is also 

--- a/examples/raisimpy_gym/envs/anymal/env.py
+++ b/examples/raisimpy_gym/envs/anymal/env.py
@@ -253,9 +253,11 @@ class AnymalEnv(RaisimGymEnv):
 
     def is_terminal_state(self):
         # if the contact body is not the foot, the episode is over
+        self.done = False
         for contact in self.robot.get_contacts():
             if contact.get_local_body_index() not in self.foot_indices:
                 self.done = True
+
         return self.done
 
     def set_seed(self, seed=None):

--- a/include/visualizer/raisimBasicImguiPanel.hpp
+++ b/include/visualizer/raisimBasicImguiPanel.hpp
@@ -104,9 +104,9 @@ void imguiRenderCallBack() {
       } else
         ImGui::Text("Unnamed object");
 
-      raisim::Vec<3> pos; ro->getPosition_W(li, pos);
-      raisim::Vec<3> vel; ro->getVelocity_W(li, vel);
-      raisim::Vec<4> ori; raisim::Mat<3,3> mat; ro->getOrientation_W(li, mat); raisim::rotMatToQuat(mat, ori);
+      raisim::Vec<3> pos; ro->getPosition(li, pos);
+      raisim::Vec<3> vel; ro->getVelocity(li, vel);
+      raisim::Vec<4> ori; raisim::Mat<3,3> mat; ro->getOrientation(li, mat); raisim::rotMatToQuat(mat, ori);
       ImGui::PopFont();
 
       ImGui::PushFont(fontMid);

--- a/src/articulated_system.cpp
+++ b/src/articulated_system.cpp
@@ -1068,7 +1068,7 @@ void init_articulated_system(py::module &m) { // py::module &main_module) {
         .def("get_world_position", [](raisim::ArticulatedSystem &self, size_t body_idx, py::array_t<double> body_point) {
             Vec<3> pos;
             Vec<3> body_pos = convert_np_to_vec<3>(body_point);
-            self.getPosition_W(body_idx, body_pos, pos);
+            self.getPosition(body_idx, body_pos, pos);
             return convert_vec_to_np(pos);
         }, R"mydelimiter(
         Get the body's position with respect to the world frame.
@@ -1136,7 +1136,7 @@ void init_articulated_system(py::module &m) { // py::module &main_module) {
           Frames are attached to the joint position */
         .def("get_frame_world_position", [](raisim::ArticulatedSystem &self, size_t frame_id) {
             Vec<3> vec;
-            self.getFramePosition_W(frame_id, vec);
+            self.getFramePosition(frame_id, vec);
             return convert_vec_to_np(vec);
         }, R"mydelimiter(
         Get the frame position expressed in the Cartesian world frame.
@@ -1152,7 +1152,7 @@ void init_articulated_system(py::module &m) { // py::module &main_module) {
 
         .def("get_frame_world_rotation_matrix", [](raisim::ArticulatedSystem &self, size_t frame_id) {
             Mat<3, 3> mat;
-            self.getFrameOrientation_W(frame_id, mat);
+            self.getFrameOrientation(frame_id, mat);
             return convert_mat_to_np(mat);
         }, R"mydelimiter(
         Get the frame orientation as a rotation matrix expressed in the Cartesian world frame
@@ -1168,7 +1168,7 @@ void init_articulated_system(py::module &m) { // py::module &main_module) {
 
         .def("get_frame_world_quaternion", [](raisim::ArticulatedSystem &self, size_t frame_id) {
             Mat<3, 3> mat;
-            self.getFrameOrientation_W(frame_id, mat);
+            self.getFrameOrientation(frame_id, mat);
             Vec<4> quat;
             rotMatToQuat(mat, quat);
             return convert_vec_to_np(quat);
@@ -1186,7 +1186,7 @@ void init_articulated_system(py::module &m) { // py::module &main_module) {
 
         .def("get_frame_linear_velocity", [](raisim::ArticulatedSystem &self, size_t frame_id) {
             Vec<3> vec;
-            self.getFrameVelocity_W(frame_id, vec);
+            self.getFrameVelocity(frame_id, vec);
             return convert_vec_to_np(vec);
         }, R"mydelimiter(
         Get the frame linear velocity expressed in the Cartesian world frame.
@@ -1202,7 +1202,7 @@ void init_articulated_system(py::module &m) { // py::module &main_module) {
 
         .def("get_frame_angular_velocity", [](raisim::ArticulatedSystem &self, size_t frame_id) {
             Vec<3> vec;
-            self.getFrameVelocity_W(frame_id, vec);
+            self.getFrameVelocity(frame_id, vec);
             return convert_vec_to_np(vec);
         }, R"mydelimiter(
         Get the frame angular velocity expressed in the Cartesian world frame.
@@ -1218,7 +1218,7 @@ void init_articulated_system(py::module &m) { // py::module &main_module) {
 
         .def("get_world_position", [](raisim::ArticulatedSystem &self, size_t frame_id) {
             Vec<3> pos;
-            self.getPosition_W(frame_id, pos);
+            self.getPosition(frame_id, pos);
             return convert_vec_to_np(pos);
         }, R"mydelimiter(
         Get the joint frame's position with respect to the world frame.
@@ -1234,7 +1234,7 @@ void init_articulated_system(py::module &m) { // py::module &main_module) {
 
         .def("get_world_rotation_matrix", [](raisim::ArticulatedSystem &self, size_t frame_id) {
             Mat<3, 3> rot;
-            self.getFrameOrientation_W(frame_id, rot);
+            self.getFrameOrientation(frame_id, rot);
             return convert_mat_to_np(rot);
         }, R"mydelimiter(
         Get the joint frame's orientation (expressed as a rotation matrix) with respect to the world frame.
@@ -1250,7 +1250,7 @@ void init_articulated_system(py::module &m) { // py::module &main_module) {
 
         .def("get_world_quaternion", [](raisim::ArticulatedSystem &self, size_t frame_id) {
             Mat<3, 3> rot;
-            self.getFrameOrientation_W(frame_id, rot);
+            self.getFrameOrientation(frame_id, rot);
             Vec<4> quat;
             rotMatToQuat(rot, quat);
             return convert_vec_to_np(quat);
@@ -1268,7 +1268,7 @@ void init_articulated_system(py::module &m) { // py::module &main_module) {
 
         .def("get_world_linear_velocity", [](raisim::ArticulatedSystem &self, size_t frame_id) {
             Vec<3> vel;
-            self.getVelocity_W(frame_id, vel);
+            self.getVelocity(frame_id, vel);
             return convert_vec_to_np(vel);
         }, R"mydelimiter(
         Get the joint frame's linear velocity with respect to the world frame.
@@ -1287,7 +1287,7 @@ void init_articulated_system(py::module &m) { // py::module &main_module) {
             MatDyn mat = convert_np_to_matdyn(jacobian);
             jac.v = mat;
             Vec<3> vel;
-            self.getVelocity_W(jac, vel);
+            self.getVelocity(jac, vel);
             return convert_vec_to_np(vel);
         }, R"mydelimiter(
         Return the velocity of the point of the sparse linear jacobian.
@@ -1305,7 +1305,7 @@ void init_articulated_system(py::module &m) { // py::module &main_module) {
                 py::array_t<double> body_pos) {
             Vec<3> pos = convert_np_to_vec<3>(body_pos);
             Vec<3> vel;
-            self.getVelocity_W(body_id, pos, vel);
+            self.getVelocity(body_id, pos, vel);
             return convert_vec_to_np(vel);
         }, R"mydelimiter(
         Return the velocity of a point (expressed in the body frame) in the world frame.
@@ -1322,7 +1322,7 @@ void init_articulated_system(py::module &m) { // py::module &main_module) {
 
         .def("get_world_angular_velocity", [](raisim::ArticulatedSystem &self, size_t body_id) {
             Vec<3> vel;
-            self.getAngularVelocity_W(body_id, vel);
+            self.getAngularVelocity(body_id, vel);
             return convert_vec_to_np(vel);
         }, R"mydelimiter(
         Get the angular velocity of the body with respect to the world frame.

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -170,7 +170,7 @@ void init_object(py::module &m) {
 
 	    .def("get_world_position", [](raisim::Object &self, size_t local_idx) {
 	        Vec<3> pos;
-	        self.getPosition_W(local_idx, pos);
+	        self.getPosition(local_idx, pos);
 	        // convert vec<3> to np.array[3]
 	        return convert_vec_to_np(pos);
 	    }, R"mydelimiter(
@@ -187,7 +187,7 @@ void init_object(py::module &m) {
 
 	    .def("get_world_linear_velocity", [](raisim::Object &self, size_t local_idx) {
 	        Vec<3> vel;
-	        self.getVelocity_W(local_idx, vel);
+	        self.getVelocity(local_idx, vel);
 	        return convert_vec_to_np(vel);
 	    }, R"mydelimiter(
 	    Get the world linear velocity.
@@ -203,7 +203,7 @@ void init_object(py::module &m) {
 
 	    .def("get_world_rotation_matrix", [](raisim::Object &self, size_t local_idx) {
 	        Mat<3,3> rot;
-	        self.getOrientation_W(local_idx, rot);
+	        self.getOrientation(local_idx, rot);
 	        return convert_mat_to_np(rot);
 	    }, R"mydelimiter(
 	    Get the world orientation as a rotation matrix.
@@ -220,7 +220,7 @@ void init_object(py::module &m) {
 	    .def("get_world_position", [](raisim::Object &self, size_t local_idx, py::array_t<double> body_pos) {
 	        Vec<3> pos_b =convert_np_to_vec<3>(body_pos);
 	        Vec<3> pos;
-	        self.getPosition_W(local_idx, pos_b, pos);
+	        self.getPosition(local_idx, pos_b, pos);
 	        return convert_vec_to_np(pos);
 	     })
 	    .def("get_body_type", py::overload_cast<size_t>(&raisim::Object::getBodyType, py::const_))

--- a/src/single_bodies.cpp
+++ b/src/single_bodies.cpp
@@ -101,7 +101,7 @@ void init_single_bodies(py::module &m) {
 	    )mydelimiter")
 
 
-	    .def("get_position", &raisim::SingleBodyObject::getPosition, R"mydelimiter(
+	    .def("get_position", py::overload_cast<>(&raisim::SingleBodyObject::getPosition), R"mydelimiter(
 	    Get the body's position with respect to the world frame.
 
 	    Returns:
@@ -117,7 +117,7 @@ void init_single_bodies(py::module &m) {
 	    )mydelimiter")
 
 
-	    .def("get_linear_velocity", &raisim::SingleBodyObject::getLinearVelocity, R"mydelimiter(
+	    .def("get_linear_velocity", py::overload_cast<>(&raisim::SingleBodyObject::getLinearVelocity), R"mydelimiter(
 	    Get the body's linear velocity with respect to the world frame.
 
 	    Returns:
@@ -125,7 +125,7 @@ void init_single_bodies(py::module &m) {
 	    )mydelimiter")
 
 
-	    .def("get_angular_velocity", &raisim::SingleBodyObject::getAngularVelocity, R"mydelimiter(
+	    .def("get_angular_velocity", py::overload_cast<>(&raisim::SingleBodyObject::getAngularVelocity), R"mydelimiter(
 	    Get the body's angular velocity position with respect to the world frame.
 
 	    Returns:
@@ -134,7 +134,7 @@ void init_single_bodies(py::module &m) {
 
 
         // this is the same as get_position
-        .def("get_world_position", &raisim::SingleBodyObject::getPosition, R"mydelimiter(
+        .def("get_world_position", py::overload_cast<>(&raisim::SingleBodyObject::getPosition), R"mydelimiter(
 	    Get the body's position with respect to the world frame.
 
 	    Returns:


### PR DESCRIPTION
Hi Brian,

As the title said, I made a version compatible with raisim v0.3.0. Unfortunately, there was API changes in v0.3.0. all prefixes "_W" in the method names are gone. so instead of ArticulatedSystem::getPosition_W(), we use ArticulatedSystem::getPosition() now. This change should make the naming in raisim more consistent. There was no API change on python side so it should not affect your code

I tried raisimpy_gym for curiosity. There was a small bug and I fixed it as well. Now it should be running. I assume that the code is single-threaded (or single process) and that's why it is so slow. it is more than 10 times slower than raisimGym

cheers,
Jemin